### PR TITLE
Fix `go get` command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you prefer, you may instead build the client in go.
 
 Run the following command to create the *artifactory-cli-go* project:
 ```console
-$ go get github.com/JFrogDev/artifactory-cli-go
+$ go get github.com/JFrogDev/artifactory-cli-go/...
 ```
 
 Navigate to the following directory


### PR DESCRIPTION
As demonstrated below in a Docker container running the official golang image, the previous command didn't work: 

```
$ docker run -it golang
root@a09850143f57:/go# go get github.com/JFrogDev/artifactory-cli-go
package github.com/JFrogDev/artifactory-cli-go: no buildable Go source files in /go/src/github.com/JFrogDev/artifactory-cli-go
root@a09850143f57:/go# echo $GOPATH
/go
root@a09850143f57:/go# go get github.com/JFrogDev/artifactory-cli-go/...
root@a09850143f57:/go# ls /go/bin
art
```
